### PR TITLE
Initial version for M2doc Capella commandline extension

### DIFF
--- a/plugins/org.obeonetwork.capella.m2doc.commandline/.classpath
+++ b/plugins/org.obeonetwork.capella.m2doc.commandline/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="lib" path="C:/Programs/capella-studio-1.3.0/jars/org.kohsuke.args4j_2.33.0.v20160323-2218.jar"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/plugins/org.obeonetwork.capella.m2doc.commandline/.project
+++ b/plugins/org.obeonetwork.capella.m2doc.commandline/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.obeonetwork.capella.m2doc.commandline</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/plugins/org.obeonetwork.capella.m2doc.commandline/.settings/org.eclipse.jdt.core.prefs
+++ b/plugins/org.obeonetwork.capella.m2doc.commandline/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+#Thu Jul 04 08:45:16 CEST 2013
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
+org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.6

--- a/plugins/org.obeonetwork.capella.m2doc.commandline/META-INF/MANIFEST.MF
+++ b/plugins/org.obeonetwork.capella.m2doc.commandline/META-INF/MANIFEST.MF
@@ -1,0 +1,16 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: %pluginName
+Bundle-SymbolicName: org.obeonetwork.capella.m2doc.commandline;singleton:=true
+Bundle-Version: 1.3.0.qualifier
+Bundle-Vendor: %providerName
+Require-Bundle: org.eclipse.ui,
+ org.polarsys.capella.core.commandline.core,
+ org.obeonetwork.m2doc;bundle-version="0.10.0",
+ org.obeonetwork.m2doc.genconf;bundle-version="0.10.0",
+ org.obeonetwork.m2doc.ide;bundle-version="[3.0.0,4.0.0)" 
+Bundle-ActivationPolicy: lazy
+Bundle-ClassPath: .
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Export-Package: org.obeonetwork.capella.m2doc.commandline
+Bundle-Localization: plugin

--- a/plugins/org.obeonetwork.capella.m2doc.commandline/build.properties
+++ b/plugins/org.obeonetwork.capella.m2doc.commandline/build.properties
@@ -1,0 +1,18 @@
+###############################################################################
+# Copyright (c) 2006, 2015 THALES GLOBAL SERVICES.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+# 
+# Contributors:
+#   Thales - initial API and implementation
+###############################################################################
+#Properties file for org.polarsys.capella.docgen.commandline
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .,\
+               plugin.xml,\
+               about.html,\
+               plugin.properties

--- a/plugins/org.obeonetwork.capella.m2doc.commandline/plugin.properties
+++ b/plugins/org.obeonetwork.capella.m2doc.commandline/plugin.properties
@@ -1,0 +1,13 @@
+###############################################################################
+# Copyright (c) 2006, 2015 THALES GLOBAL SERVICES.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+# 
+# Contributors:
+#   Thales - initial API and implementation
+###############################################################################
+#Properties file for org.polarsys.capella.docgen.commandline
+pluginName=Capella M2Doc Commandline
+providerName=Obeonetwork

--- a/plugins/org.obeonetwork.capella.m2doc.commandline/plugin.xml
+++ b/plugins/org.obeonetwork.capella.m2doc.commandline/plugin.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2006, 2019 THALES GLOBAL SERVICES.
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html
+ 
+Contributors:
+  Thales - initial API and implementation
+-->
+
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="org.polarsys.capella.core.commandline.core.commandline">
+      <CommandlineExtension
+            class="org.obeonetwork.capella.m2doc.commandline.M2DocCommandLine"
+            id="org.obeonetwork.capella.m2doc.commandline">
+      </CommandlineExtension>
+   </extension>
+
+</plugin>

--- a/plugins/org.obeonetwork.capella.m2doc.commandline/src/org/obeonetwork/capella/m2doc/commandline/CLIUtils.java
+++ b/plugins/org.obeonetwork.capella.m2doc.commandline/src/org/obeonetwork/capella/m2doc/commandline/CLIUtils.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Obeo.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.obeonetwork.capella.m2doc.commandline;
+
+import java.io.PrintStream;
+
+import org.eclipse.emf.common.util.BasicMonitor;
+import org.eclipse.emf.common.util.Diagnostic;
+
+public final class CLIUtils {
+	
+	public static final String RESET = "\u001B[0m";
+	public static final String BLACK = "\u001B[30;40;1m";
+	public static final String RED = "\u001B[31;40;1m";
+	public static final String GREEN = "\u001B[32;40;1m";
+	public static final String YELLOW = "\u001B[33;40;1m";
+	public static final String BLUE = "\u001B[34;40;1m";
+	public static final String PURPLE = "\u001B[35;40;1m";
+	public static final String CYAN = "\u001B[36;40;1m";
+	public static final String WHITE = "\u001B[37;40;1m";
+
+
+	private static CLIDecorator decorator;
+	
+	private CLIUtils() {
+
+	}
+
+	public static CLIDecorator getDecorator() {
+		if (decorator == null) {
+			String colorTerm = System.getenv().get("COLORTERM");
+			if (colorTerm != null && "1".equals(colorTerm)) {
+				decorator = new CLIDecorator();
+			} else {
+				decorator = new NoDecoration();
+			}
+		}
+		return decorator;
+	}
+
+	public static class CLIDecorator {
+
+		public String red(String txt) {
+			return RED + txt + RESET;
+		}
+
+		public String black(String txt) {
+			return BLACK + txt + RESET;
+		}
+
+		public String green(String txt) {
+			return GREEN + txt + RESET;
+		}
+
+		public String yellow(String txt) {
+			return YELLOW + txt + RESET;
+		}
+
+		public String blue(String txt) {
+			return BLUE + txt + RESET;
+		}
+
+		public String purple(String txt) {
+			return PURPLE + txt + RESET;
+		}
+
+		public String cyan(String txt) {
+			return CYAN + txt + RESET;
+		}
+
+		public String white(String txt) {
+			return WHITE + txt + RESET;
+		}
+	}
+
+	public static class NoDecoration extends CLIDecorator {
+		public String red(String txt) {
+			return txt;
+		}
+
+		public String black(String txt) {
+			return txt;
+		}
+
+		public String green(String txt) {
+			return txt;
+		}
+
+		public String yellow(String txt) {
+			return txt;
+		}
+
+		public String blue(String txt) {
+			return txt;
+		}
+
+		public String purple(String txt) {
+			return txt;
+		}
+
+		public String cyan(String txt) {
+			return txt;
+		}
+
+		public String white(String txt) {
+			return txt;
+		}
+	}
+	
+	
+	/**
+	 * A simple monitor that prints progress to a print stream.
+	 */
+	public static class ColoredPrinting extends BasicMonitor {
+		protected PrintStream printStream;
+
+		public ColoredPrinting(PrintStream printStream) {
+			this.printStream = printStream;
+		}
+
+		@Override
+		public void beginTask(String name, int totalWork) {
+			if (name != null && name.length() != 0) {
+				printStream.println(BLUE + ">>> " + name + WHITE);
+			}
+		}
+
+		@Override
+		public void setTaskName(String name) {
+			if (name != null && name.length() != 0) {
+				printStream.println("<>> " + name);
+			}
+		}
+
+		@Override
+		public void subTask(String name) {
+			if (name != null && name.length() != 0) {
+				printStream.println(CYAN + ">>  " + name + WHITE);
+			}
+		}
+
+		@Override
+		public void setBlocked(Diagnostic reason) {
+			super.setBlocked(reason);
+			printStream.println(RED + "#>  " + reason.getMessage() + WHITE);
+		}
+
+		@Override
+		public void clearBlocked() {
+			printStream.println(GREEN + "=>  " + getBlockedReason().getMessage() + WHITE);
+			super.clearBlocked();
+		}
+	}
+
+}

--- a/plugins/org.obeonetwork.capella.m2doc.commandline/src/org/obeonetwork/capella/m2doc/commandline/M2DocCommandLine.java
+++ b/plugins/org.obeonetwork.capella.m2doc.commandline/src/org/obeonetwork/capella/m2doc/commandline/M2DocCommandLine.java
@@ -1,0 +1,211 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2018 THALES GLOBAL SERVICES.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *  
+ * Contributors:
+ *   Thales - initial API and implementation
+ ******************************************************************************/
+
+package org.obeonetwork.capella.m2doc.commandline;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.eclipse.emf.common.util.Monitor;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.equinox.app.IApplicationContext;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.application.WorkbenchAdvisor;
+import org.polarsys.capella.core.commandline.core.AbstractCommandLine;
+import org.polarsys.capella.core.commandline.core.CommandLineException;
+import org.obeonetwork.m2doc.genconf.GenconfUtils;
+import org.obeonetwork.m2doc.genconf.Generation;
+import org.obeonetwork.m2doc.generator.DocumentGenerationException;
+import org.obeonetwork.m2doc.ide.M2DocPlugin;
+import org.obeonetwork.m2doc.parser.DocumentParserException;
+
+/**
+ * 
+ */
+public class M2DocCommandLine extends AbstractCommandLine {
+	
+	private String[] genconfs = new String[1];
+	
+	/**
+   * 
+   */
+	public M2DocCommandLine() {
+		super();
+	}
+
+	@Override
+	public void printHelp() {
+		System.out.println("Capella M2Doc Command Line"); //$NON-NLS-1$
+		super.printHelp();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void checkArgs(IApplicationContext context_p) throws CommandLineException {
+		super.checkArgs(context_p);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean execute(IApplicationContext context_p) {
+
+		startFakeWorkbench();
+		
+		genconfs[0] = "platform:/resource/" + argHelper.getFilePath();
+		Collection<URI> genconfsURIs = validateArguments();
+
+        boolean somethingWentWrong = false;
+	        
+        System.out.println(CLIUtils.getDecorator()
+                .purple(" __          __  _                            _          __  __ ___     _            \n"
+                    + " \\ \\        / / | |                          | |        |  \\/  |__ \\   | |           \n"
+                    + "  \\ \\  /\\  / /__| | ___ ___  _ __ ___   ___  | |_ ___   | \\  / |  ) |__| | ___   ___ \n"
+                    + "   \\ \\/  \\/ / _ \\ |/ __/ _ \\| '_ ` _ \\ / _ \\ | __/ _ \\  | |\\/| | / // _` |/ _ \\ / __|\n"
+                    + "    \\  /\\  /  __/ | (_| (_) | | | | | |  __/ | || (_) | | |  | |/ /| (_| | (_) | (__ \n"
+                    + "     \\/  \\/ \\___|_|\\___\\___/|_| |_| |_|\\___|  \\__\\___/  |_|  |_|____\\__,_|\\___/ \\___|"));
+        
+        
+        System.out.println(
+                CLIUtils.getDecorator().yellow("The command-line launcher to generate .docx from your models."));
+
+        System.out.println(CLIUtils.RESET);
+
+        Collection<Generation> loadedGenConfs = new ArrayList<Generation>();
+
+        ResourceSet s = new ResourceSetImpl();
+        for (URI uri : genconfsURIs) {
+            if (s.getURIConverter().exists(uri, Collections.EMPTY_MAP)) {
+                try {
+                    Resource r = s.getResource(uri, true);
+                    r.load(Collections.EMPTY_MAP);
+                    for (EObject eObj : r.getContents()) {
+                        if (eObj instanceof Generation) {
+                            loadedGenConfs.add((Generation) eObj);
+                        }
+                    }
+                } catch (IOException e) {
+                    somethingWentWrong = true;
+                    logInfo("Error loading genconf: '" + uri.toString() + "' : " + e.getMessage());
+                    // CHECKSTYLE:OFF we want to report any error
+                } catch (RuntimeException e) {
+                    // CHECKSTYLE:ON
+                    somethingWentWrong = true;
+                    logError("Error loading genconf: '" + uri.toString() + "' : " + e.getMessage());
+                }
+            } else {
+                logError("Error loading genconf: '" + uri.toString() + "' : does not exist or is not accessible.");
+            }
+        }
+
+        final Monitor monitor = new CLIUtils.ColoredPrinting(System.out);
+        
+        monitor.beginTask("Generating .docx documents", loadedGenConfs.size());
+        for (Generation generation : loadedGenConfs) {
+            try {
+
+                System.out.println("Input: " + generation.eResource().getURI());
+                List<URI> generated = GenconfUtils.generate(generation, M2DocPlugin.getClassProvider(), monitor);
+                for (URI uri : generated) {
+                    System.out.println("Output: " + uri.toString());
+                }
+                monitor.worked(1);
+
+            } catch (DocumentGenerationException e) {
+                logError("Error launching genconf: '"
+                            + generation.eResource().getURI().toString() + "' : " + e.getMessage());
+            } catch (IOException e) {
+                logError("Error launching genconf: '"
+                            + generation.eResource().getURI().toString() + "' : " + e.getMessage());
+            } catch (DocumentParserException e) {
+                logError("Error launching genconf: '"
+                            + generation.eResource().getURI().toString() + "' : " + e.getMessage());
+            }
+        }
+	 
+
+		return !somethingWentWrong;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * 
+	 * @throws CommandLineException
+	 */
+	@Override
+	public void prepare(IApplicationContext context_p) throws CommandLineException {
+		super.prepare(context_p);
+	}
+
+	public static void startFakeWorkbench() {
+		Display display = PlatformUI.createDisplay();
+		PlatformUI.createAndRunWorkbench(display, new WorkbenchAdvisor() {
+
+			/**
+			 * {@inheritDoc}
+			 */
+			@Override
+			public boolean openWindows() {
+				return false;
+			}
+
+			@Override
+			public String getInitialWindowPerspectiveId() {
+				return null;
+			}
+		});
+	}
+	
+    /**
+     * Validate arguments which are mandatory only in some circumstances.
+     */
+	
+    private Collection<URI> validateArguments() {
+        Collection<URI> result = new ArrayList<URI>();
+        
+        if (genconfs == null || genconfs.length == 0) {
+            //throw new CmdLineException(parser, "You must specify genconfs models.");
+        }
+        for (String modelPath : genconfs) {
+
+            URI rawURI = null;
+            try {
+                rawURI = URI.createURI(modelPath, true);
+            } catch (IllegalArgumentException e) {
+                
+                 // the passed uri is not in the URI format and should be
+                 // considered as a direct file denotation.
+                
+            }
+
+            if (rawURI != null && !rawURI.hasAbsolutePath()) {
+                rawURI = URI.createFileURI(modelPath);
+            }
+            result.add(rawURI);
+        }
+
+        return result;
+
+    }
+    
+	
+
+}

--- a/plugins/org.obeonetwork.capella.m2doc.commandline/src/org/obeonetwork/capella/m2doc/commandline/M2DocCommandLineActivator.java
+++ b/plugins/org.obeonetwork.capella.m2doc.commandline/src/org/obeonetwork/capella/m2doc/commandline/M2DocCommandLineActivator.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2015 THALES GLOBAL SERVICES.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *  
+ * Contributors:
+ *   Thales - initial API and implementation
+ ******************************************************************************/
+
+package org.obeonetwork.capella.m2doc.commandline;
+
+import org.eclipse.core.runtime.Plugin;
+
+public class M2DocCommandLineActivator extends Plugin {
+	public static final String PLUGIN_ID = "org.obeonetwork.capella.m2doc.commandline"; //$NON-NLS-1$
+
+}

--- a/plugins/org.obeonetwork.capella.m2doc.commandline/src/org/obeonetwork/capella/m2doc/commandline/Messages.java
+++ b/plugins/org.obeonetwork.capella.m2doc.commandline/src/org/obeonetwork/capella/m2doc/commandline/Messages.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2017 THALES GLOBAL SERVICES.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *  
+ * Contributors:
+ *   Thales - initial API and implementation
+ ******************************************************************************/
+
+package org.obeonetwork.capella.m2doc.commandline;
+
+import org.eclipse.osgi.util.NLS;
+
+/**
+ * 
+ */
+public class Messages extends NLS {
+	private static final String BUNDLE_NAME = "org.obeonetwork.capella.m2doc.commandline.messages"; //$NON-NLS-1$
+	public static String workspace_in_use;
+	public static String project;
+	public static String not_exist;
+	public static String outputfolder_mandatory;
+	public static String aird;
+	public static String exec_pb;
+	public static String filepath_point_to_aird;
+	public static String generation_done;
+	public static String no_root_semantic_element;
+	public static String representation_mandatory;
+	public static String resource_prefix;
+	static {
+		// initialize resource bundle
+		NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+	}
+
+	private Messages() {
+	}
+}

--- a/plugins/org.obeonetwork.capella.m2doc.commandline/src/org/obeonetwork/capella/m2doc/commandline/messages.properties
+++ b/plugins/org.obeonetwork.capella.m2doc.commandline/src/org/obeonetwork/capella/m2doc/commandline/messages.properties
@@ -1,0 +1,23 @@
+###############################################################################
+# Copyright (c) 2006, 2017 THALES GLOBAL SERVICES.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#  
+# Contributors:
+#   Thales - initial API and implementation
+###############################################################################
+#Properties file for org.obeonetwork.capella.m2doc.commandline
+
+outputfolder_mandatory=Output folder argument is mandatory\!
+aird=Representation file 
+exec_pb=Execution problem : 
+filepath_point_to_aird=filepath argument should point to an genconf file relative to workspace (*.genconf)\!
+generation_done=Doc generation done\!\n files generated to 
+no_root_semantic_element=No root semantic element (Library or Project) found in the given model\!
+representation_mandatory=Representation file path argument is mandatory\!
+resource_prefix=platform:/resource/
+workspace_in_use=Workspace already in use
+project=project 
+not_exist=\ does not exist\!


### PR DESCRIPTION
A new plugin org.obeonetwork.capella.m2doc.commandline is an extension for Capella command line application that allows to launch m2doc generations based on Capella models from command line. 