### PR TITLE
ReplaceLink service does not handle Team for Capella session with representation lazy loading enabled #34

### DIFF
--- a/plugins/org.obeonetwork.capella.m2doc.aql.queries/src/org/obeonetwork/capella/m2doc/aql/queries/M2DocGenServices.java
+++ b/plugins/org.obeonetwork.capella.m2doc.aql.queries/src/org/obeonetwork/capella/m2doc/aql/queries/M2DocGenServices.java
@@ -394,6 +394,16 @@ public class M2DocGenServices extends AbstractServiceProvider {
             final Resource airResource = session.getSessionResource();
             repEObject = airResource.getEObject(id);
 
+            // Aird can be fragmented or manage several airds.
+            if (repEObject == null) {
+                for (Resource otherAirds : session.getReferencedSessionResources()) {
+                    repEObject = otherAirds.getEObject(id);
+                    if (repEObject != null) {
+                        break;
+                    }
+                }
+            }
+
             // Aird can be split into several resource, representations can be stored in their own .srm resources.
             if (repEObject == null) {
                 for (Resource srmResource : session.getSrmResources()) {

--- a/plugins/org.obeonetwork.capella.m2doc.aql.queries/src/org/obeonetwork/capella/m2doc/aql/queries/M2DocGenServices.java
+++ b/plugins/org.obeonetwork.capella.m2doc.aql.queries/src/org/obeonetwork/capella/m2doc/aql/queries/M2DocGenServices.java
@@ -414,15 +414,18 @@ public class M2DocGenServices extends AbstractServiceProvider {
                 }
             }
 
-            // Some srm resource might not be loaded yet (lazy loading of DRepresentation content
-            for (DRepresentationDescriptor repDesc : DialectManager.INSTANCE.getAllRepresentationDescriptors(session)) {
-                ResourceDescriptor representationPath = repDesc.getRepPath();
-                if (representationPath.getResourceURI().toString().contains(id)) {
-                    // Load representation if repPath contains the searched id
-                    DRepresentation rep = repDesc.getRepresentation();
-                    if (rep != null && id.equals(rep.getUid())) {
-                        repEObject = rep;
-                        break;
+            // Some srm resource might not be loaded yet (lazy loading of DRepresentation content)
+            if (repEObject == null) {
+                for (DRepresentationDescriptor repDesc : DialectManager.INSTANCE
+                        .getAllRepresentationDescriptors(session)) {
+                    ResourceDescriptor representationPath = repDesc.getRepPath();
+                    if (representationPath.getResourceURI().toString().contains(id)) {
+                        // Load representation if repPath contains the searched id
+                        DRepresentation rep = repDesc.getRepresentation();
+                        if (rep != null && id.equals(rep.getUid())) {
+                            repEObject = rep;
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Two additional commits to manage fragmented Sirius/Capella sessions and optimize repDesc lookup (do it only if previous cases did not work)