### PR TITLE
Enable absolute path to genconf in command line arguments.

### DIFF
--- a/plugins/org.obeonetwork.capella.m2doc.commandline/src/org/obeonetwork/capella/m2doc/commandline/M2DocCommandLine.java
+++ b/plugins/org.obeonetwork.capella.m2doc.commandline/src/org/obeonetwork/capella/m2doc/commandline/M2DocCommandLine.java
@@ -77,7 +77,7 @@ public class M2DocCommandLine extends AbstractWorkbenchCommandLine {
 
 		startFakeWorkbench();
 
-		genconfs[0] = "platform:/resource/" + CommandLineArgumentHelper.getInstance().getFilePath();
+		genconfs[0] = CommandLineArgumentHelper.getInstance().getFilePath();
 		Collection<URI> genconfsURIs = validateArguments();
 
 		boolean somethingWentWrong = false;


### PR DESCRIPTION
This PR concern with arguments handling when launching m2doc publishing from command line.

Currently it’s not possible to use absolute file path to genconf (file:///) .
It's possible to use only workspace path with current realization of M2DocCommandLine.

As a result it's not possible to launch publication without workspace creation and project import to it.
It's not good for use case when m2doc command line publishing is used in automatic scripts (in Jenkins for example)

In the current realization platform type “platform:/resource/” is added to the genconf file path provided in command line arguments
genconfs[0] = “platform:/resource/” + CommandLineArgumentHelper.getInstance().getFilePath();

This line needs to be changed to
genconfs[0] = CommandLineArgumentHelper.getInstance().getFilePath();

After that absolute path usage to genconf in command line arguments becomes also possible.
file:///publish/capella_project/genconfs/test.genconf

In this case -data arguments can point to non existing folder for new eclipse workspace or
to the existing one (event without projects imported). 

When absolute path to genconf is used relative paths to aird and capella files should be used inside genconf file.

I've tested this modification. 
Document with diargams was successfully published based on absolute path to genconf.

This modification has a side effects.
After this modification users should used “platform:/resource/” prefix in command line arguments to genconf file
when path is defined relative to workspace.
Previous workspace paths (without platform:/resource/) will not continue to work.

So this modification crashes existing command line API. 
May be we need to add platform:/resource/ in the code in case file:/// is not used for genconf 
to save current API.

